### PR TITLE
Cache the ARM GCC download

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,30 +27,57 @@ jobs:
       if: runner.os == 'macOS'
       run: brew bundle
 
+    - name: Cache ARM GCC
+      uses: actions/cache@v1
+      with:
+        path: downloads
+        key: ${{ runner.os }}-v1 # bump this version number when changing any of the downloaded binaries
+
     - name: Install Linux dependencies
       if: runner.os == 'Linux'
       run: |
-        sudo apt install wget file ninja-build gperf ccache dfu-util make gdb-multiarch xz-utils
+        sudo apt-get install wget file ninja-build gperf ccache dfu-util make gdb-multiarch xz-utils
+        
+        if [[ -d ./downloads ]]; then
+          echo "Using cached downloads"
+        else
+          echo "Cached downloads missing. Downloading..."
+          mkdir downloads
+          wget -P ./downloads -nv http://mirrors.kernel.org/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.7-1_amd64.deb
+          wget -P ./downloads -nv https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2-Linux-x86_64.tar.gz
+          sudo wget -P ./downloads -nv https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
+        fi
+
         # install device-tree-compiler
-        wget http://mirrors.kernel.org/ubuntu/pool/main/d/device-tree-compiler/device-tree-compiler_1.4.7-1_amd64.deb
-        sudo dpkg -i device-tree-compiler_1.4.7-1_amd64.deb
+        sudo dpkg -i ./downloads/device-tree-compiler_1.4.7-1_amd64.deb
+
         # install cmake
-        sudo wget -P /opt -nv https://github.com/Kitware/CMake/releases/download/v3.16.2/cmake-3.16.2-Linux-x86_64.tar.gz
-        sudo tar zxf /opt/cmake-3.16.2-Linux-x86_64.tar.gz -C /opt
+        sudo tar zxf ./downloads/cmake-3.16.2-Linux-x86_64.tar.gz -C /opt
         sudo ln -s /opt/cmake-3.16.2-Linux-x86_64/bin/* /usr/local/sbin
         cmake --version
+
         # gcc-arm-none-eabi
-        sudo wget -P /opt -nv https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2
-        sudo tar jxf /opt/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2 -C /opt
+        sudo tar jxf ./downloads/gcc-arm-none-eabi-8-2019-q3-update-linux.tar.bz2 -C /opt
+        echo "Installed gcc-arm-none-eabi-8-2019-q3-update to /opt/gcc-arm-none-eabi-8-2019-q3-update"
 
     - name: Install Windows dependencies
       if: runner.os == 'Windows'
       run: |
         choco install -y cmake --installargs 'ADD_CMAKE_TO_PATH=System' --no-progress
         choco install ninja dtc-msys2 gperf --no-progress
-        $ProgressPreference = 'SilentlyContinue'
-        Invoke-WebRequest https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-win32.zip -OutFile gcc-arm-win32.zip
-        7z x -bd -oC:\gnuarmemb .\gcc-arm-win32.zip
+        
+        if (Test-Path "downloads") {
+          Write-Host "Using cached downloads"
+        } else {
+          Write-Host "Cached downloads missing. Downloading..."
+          mkdir downloads
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest https://developer.arm.com/-/media/Files/downloads/gnu-rm/8-2019q3/RC1.1/gcc-arm-none-eabi-8-2019-q3-update-win32.zip -OutFile downloads\gcc-arm-none-eabi-8-2019-q3-update-win32.zip -TimeoutSec 180
+        }
+
+        # gcc-arm-none-eabi
+        7z x -bd -oC:\gnuarmemb .\downloads\gcc-arm-none-eabi-8-2019-q3-update-win32.zip
+        Write-Host "Installed gcc-arm-none-eabi-8-2019-q3-update to C:\gnuarmemb"
         
     - name: Set up Python 3.7
       uses: actions/setup-python@v1


### PR DESCRIPTION
Many of the builds fail because the ARM download server is not responding. This PR adds caching on the downloaded binaries. Which should reduce the number of failed builds substantially.